### PR TITLE
Go metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ debug
 .vscode/*
 *.iml
 
+config.yml
 

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-replace github.com/DNS-OARC/ripeatlas v0.0.0-20171113072002-0ef1b8935530 => github.com/digitalocean/ripeatlas v0.0.0-20210505184633-cc23804aa35e
+replace github.com/DNS-OARC/ripeatlas => github.com/digitalocean/ripeatlas v0.0.0-20210505184633-cc23804aa35e

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -14,6 +13,7 @@ import (
 	"github.com/czerwonk/atlas_exporter/atlas"
 	"github.com/czerwonk/atlas_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
 
 	_ "net/http/pprof"
@@ -39,6 +39,7 @@ var (
 	profiling        = flag.Bool("profiling", false, "Enables pprof endpoints")
 	goMetrics        = flag.Bool("metrics.go", true, "Enables go runtime prometheus metrics")
 	processMetrics   = flag.Bool("metrics.process", true, "Enables process runtime prometheus metrics")
+	logLevel         = flag.String("log.level", "info", "Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]")
 	cfg              *config.Config
 	strategy         atlas.Strategy
 )
@@ -53,6 +54,9 @@ func init() {
 
 func main() {
 	flag.Parse()
+
+	logger := log.Base()
+	logger.SetLevel(*logLevel)
 
 	if *showVersion {
 		printVersion()


### PR DESCRIPTION
This adds flags to enable go and process runtime metrics to be exported, as well as a log.level flag. Tested locally